### PR TITLE
fix: correct typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ class QObjectChild: public QObject {
 ...
 
     bool event(QEvent* ev) override {
-        if (auto sdl = dynamci_cast<QSDLEvent>(ev)) {
+        if (auto sdl = dynamic_cast<QSDLEvent>(ev)) {
             ...
         }
     }


### PR DESCRIPTION
Hi,

I haven’t used this project yet, but it caught my attention. While reading through the README, I noticed a small typo in the example code. This PR updates `dynamci_cast<QSDLEvent>(ev)` to `dynamic_cast<QSDLEvent>(ev)`.

Best,
Alex